### PR TITLE
Improve architecture

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -14,7 +14,7 @@ data:
   dataset: shakespeare # 'openwebtext', 'shakespeare', 'openai_summarize_tldr'
   gradient_accumulation_steps: 1 # used to simulate larger batch sizes
   batch_size: 12 # if gradient_accumulation_steps > 1, this is the micro-batch size
-  block_size: 64
+  block_size: 32
 model:
   n_layer: 2
   n_head: 2

--- a/config/config_reward.yaml
+++ b/config/config_reward.yaml
@@ -16,11 +16,11 @@ data:
   dataset: 'shakespeare' # 'openwebtext', 'shakespeare', 'openai_summarize_tldr'
   gradient_accumulation_steps: 1 # used to simulate larger batch sizes
   batch_size: 64 # if gradient_accumulation_steps > 1, this is the micro-batch size
-  block_size: 16
+  block_size: 32
 model:
-  n_layer: 1
-  n_head: 1
-  n_embd: 16
+  n_layer: 2
+  n_head: 2
+  n_embd: 32
   dropout: 0.0 # for pretraining 0 is good, for finetuning try 0.1+
   bias: False # do we use bias inside LayerNorm and Linear layers?
 optimizer: # adamw

--- a/config/config_rl.yaml
+++ b/config/config_rl.yaml
@@ -3,6 +3,7 @@ algorithm:
   hard_code_reward: False # use a learned reward model or hard code reward (latter does not work with Gumbel)
   separate_reward_model: True # when using a reward model, instantiate it separately rather than share params with LM
   discrete_reward: True # reward output is 0 or 1 sample if True, otherwise reward is continuous
+  episode_length: 32
 IO:
   out_dir: out
   eval_interval: 100
@@ -11,7 +12,7 @@ IO:
   eval_only: False # if True, script exits right after the first eval
   always_save_checkpoint: True # if True, always save a checkpoint after each eval
   init_from: resume # 'scratch' or 'resume' or 'gpt2*'
-  init_multihead_from: resume
+  init_multihead_from: scratch
   out_dir_multihead: out_reward # used if restoring multihead
 wandb:
   wandb_log: False # disabled by default
@@ -21,11 +22,11 @@ data:
   dataset: shakespeare # 'openwebtext', 'shakespeare', 'openai_summarize_tldr'
   gradient_accumulation_steps: 1 # used to simulate larger batch sizes
   batch_size: 12 # if gradient_accumulation_steps > 1, this is the micro-batch size
-  block_size: 16
+  block_size: 32
 model:
-  n_layer: 1
-  n_head: 1
-  n_embd: 16
+  n_layer: 2
+  n_head: 2
+  n_embd: 32
   dropout: 0.0 # for pretraining 0 is good, for finetuning try 0.1+
   bias: False # do we use bias inside LayerNorm and Linear layers?
 optimizer: # adamw

--- a/model.py
+++ b/model.py
@@ -511,7 +511,7 @@ class RLHF(nn.Module):
 
             # focus only on the last time step
             logits = logits[:, -1, :] # becomes (B, C)
-            # apply softmax to get probabilities
+
             
             #gumbel sample
             idx_next, onehot_next = self.gumbel_softmax(logits, tau=1, device=idx.device)

--- a/model.py
+++ b/model.py
@@ -416,33 +416,7 @@ class RLHF(nn.Module):
             return self.forward_reward(idx, targets)
         else:
             return self.model(idx, targets)
-    
-    def forward_policy(self, idx, targets=None):
-        device = idx.device
-        b, t = idx.size()
-        assert t <= self.config.block_size, f"Cannot forward sequence of length {t}, block size is only {self.config.block_size}"
-        pos = torch.arange(0, t, dtype=torch.long, device=device).unsqueeze(0) # shape (1, t)
-
-        # forward the GPT model itself
-        tok_emb = self.transformer.wte(idx) # token embeddings of shape (b, t, n_embd)
-        pos_emb = self.transformer.wpe(pos) # position embeddings of shape (1, t, n_embd)
-        x = self.transformer.drop(tok_emb + pos_emb)
-        for block in self.transformer.h:
-            x = block(x)
-        x = self.transformer.ln_f(x)
-
-        if targets is not None:
-            # if we are given some desired targets also calculate the loss
-            logits = self.policy_head(x)
-            loss = F.cross_entropy(logits.view(-1, logits.size(-1)), targets.view(-1), ignore_index=-1)
-        else:
-            # inference-time mini-optimization: only forward the lm_head on the very last position
-            logits = self.policy_head(x[:, [-1], :]) # note: using list [-1] to preserve the time dim
-            loss = None
-
-        return logits, loss
-    
-    # @torch.no_grad()
+     
     def generate(self, idx, max_new_tokens, device, block_size, use_reference=True, reward_model=None, hard_code_reward=True):
         # idx is (B, T) array of indices in the current context
         log_probs = torch.tensor([]).to(device)

--- a/trainers/reward_trainer.py
+++ b/trainers/reward_trainer.py
@@ -110,9 +110,8 @@ class RewardModelTrainer(Trainer):
     
         model.to(self.device)
 
-        self.optimizer = torch.optim.AdamW(model.model.reward_head.parameters(), lr=1e-3)
-        print(model.model.reward_head)
-        # self.optimizer = torch.optim.AdamW(model.model.parameters(), lr=1e-4)
+        # self.optimizer = torch.optim.AdamW(model.model.reward_head.parameters(), lr=1e-3)
+        self.optimizer = torch.optim.AdamW(model.model.parameters(), lr=1e-4)
 
         model = self.setup_model(model)
 

--- a/trainers/rl_trainer.py
+++ b/trainers/rl_trainer.py
@@ -181,7 +181,6 @@ class GumbelTrainer(Trainer):
             
             states, rewards = rl_model.generate_gumbel(X, self.config['episode_length'], self.device, self.block_size, reward_model=reward_model)
 
-
             loss = -rewards.mean()
             gumbel_optimizer.zero_grad(set_to_none=True)
             loss.backward()


### PR DESCRIPTION
I simplify the reward model head by only taking the final output in previous layer, if attention is working properly it should be sufficient.

I also include the gradscaler in train_rl.py and this makes training much more stable. 

I also include a comment on the current approach:

```
        # The current approach is to use a separate reward model because otherwise optimisation of the reward model changes upstream parameters impacting performance of the multihead
        # I therefore load the language model from 'out_dir' and the reward model from 'out_dir_multihead'
```